### PR TITLE
Add Severn Trent dataset.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,8 @@ data/eea.europa.eu :
 
 # --------------------------------------------------------------------------------------------------
 
-data/raw_catchments/severn_trent_water.zip :
-	$(info Severn Trent Water has not provided the data as an attachment to the Environmental \
-		Information request; see https://www.whatdotheyknow.com/r/505e5178-c611-44f7-b6db-7f1e3c599e0e \
-		for details. You can obtain the dataset by submitting your own request on whatdotheyknow.com, \
-		emailing customerEIR@severntrent.co.uk using the Environmental Information Request \
-		template in the README, or contacting the authors at till dot hoffmann at oxon dot org.)
-
 COMPANIES = anglian_water thames_water united_utilities welsh_water southern_water northumbrian_water \
-	yorkshire_water scottish_water wessex_water
+	yorkshire_water scottish_water severn_trent_water wessex_water
 DOWNLOAD_URL_anglian_water = https://www.whatdotheyknow.com/request/815216/response/2001959/attach/3/WWCATCHPOLY%2023%2004%202021.zip
 DOWNLOAD_URL_thames_water = https://www.whatdotheyknow.com/r/e5915cbb-dc3b-4797-bf75-fe7cd8eb75c0/response/1949301/attach/2/SDAC.zip
 DOWNLOAD_URL_united_utilities = https://www.whatdotheyknow.com/r/578035f9-a422-4c1b-a803-c257bf4f3414/response/1948454/attach/3/UUDrainageAreas040122.zip
@@ -75,10 +68,11 @@ DOWNLOAD_URL_southern_water = https://www.whatdotheyknow.com/r/4cde4e22-1df0-42c
 DOWNLOAD_URL_northumbrian_water = https://www.whatdotheyknow.com/r/aad55c04-bbc4-47a9-bec8-ea7e2a97f6d3/response/1934324/attach/3/STW%20Catchments.zip
 DOWNLOAD_URL_yorkshire_water = https://www.whatdotheyknow.com/r/639740ed-b0a3-4609-b4b6-a30a052fe037/response/1945306/attach/3/EIR%20Wastewater%20Catchments.zip
 DOWNLOAD_URL_scottish_water = https://www.whatdotheyknow.com/r/0998addc-63f7-4a78-ac75-17fcf9b54b7d/response/1938176/attach/4/DOAs%20and%20WWTWs.zip
+DOWNLOAD_URL_severn_trent_water = https://web.archive.org/web/20220613151243/https://www.stwater.co.uk/content/dam/stw/my-account/boundary-map-2022.zip
 DOWNLOAD_URL_wessex_water = https://www.whatdotheyknow.com/r/bda33cfd-e23d-49e6-b651-4ff8997c83c3/response/1947874/attach/2/WxW%20WRC%20Catchments%20Dec2021.zip
 DOWNLOAD_TARGETS = $(addprefix data/raw_catchments/,${COMPANIES:=.zip})
 
-data/raw_catchments : data/raw_catchments/severn_trent_water.zip ${DOWNLOAD_TARGETS}
+data/raw_catchments : ${DOWNLOAD_TARGETS}
 
 ${DOWNLOAD_TARGETS} : data/raw_catchments/%.zip :
 	mkdir -p $(dir $@)
@@ -101,7 +95,8 @@ data/validation :
 analysis : workspace/consolidate_waterbase.html \
 	workspace/consolidate_catchments.html \
 	workspace/match_waterbase_and_catchments.html \
-	workspace/estimate_population.html
+	workspace/estimate_population.html \
+	workspace/catchments_consolidated.zip
 
 ${OUTPUT_ROOT} :
 	mkdir -p $@
@@ -134,3 +129,6 @@ workspace/estimate_population.html ${OUTPUT_ROOT}/population_estimates.csv \
 		${OUTPUT_ROOT}/lsoa_catchment_lookup.csv ${OUTPUT_ROOT}/lsoa_coverage.csv \
 		${OUTPUT_ROOT}/waterbase_catchment_lookup.csv
 	${NBEXECUTE} $<
+
+${OUTPUT_ROOT}/catchments_consolidated.zip : ${OUTPUT_ROOT}/catchments_consolidated.shp
+	zip $@ ${@:.zip=}*

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,11 @@ Wastewater Catchment Areas in Great Britain
 
 This repository provides code to consolidate wastewater catchment areas in Great Britain and evaluate their spatial overlap with statistical reporting units, such as Lower Layer Super Output Areas (LSOAs). Please see the `accompanying publication <https://doi.org/10.1002/essoar.10510612.2>`__ for a detailed description of the analysis. If you have questions about the analysis, code, or accessing the data, please contact :code:`till dot hoffmann at oxon dot org`.
 
+🏁 Just give me the dataset
+--------------------------
+
+If you are interested in the consolidated dataset of wastewater catchment areas rather than reproducing the analysis, you can download it `here <https://gist.github.com/fc12349c02950e43a9edefe5907eb62c/raw/5ed839ae794c660cce623018c43ca4a96878fad4/catchments_consolidated.zip>`__ (`Shapefile <https://en.wikipedia.org/wiki/Shapefile>`__ format).
+
 💾 Data
 -------
 
@@ -49,7 +54,7 @@ Details of the submitted Environmental Information Requests can be found here:
 - 🔴 `Northern Ireland Water <https://www.whatdotheyknow.com/r/2b144b5d-abe6-4ad9-a61b-4e39f1e96e9f>`__: request refused.
 - 🟢 `Northumbrian Water <https://www.whatdotheyknow.com/r/aad55c04-bbc4-47a9-bec8-ea7e2a97f6d3>`__: data provided and publicly accessible.
 - 🟢 `Scottish Water <https://www.whatdotheyknow.com/r/0998addc-63f7-4a78-ac75-17fcf9b54b7d>`__: data provided and publicly accessible.
-- 🟡 `Severn Trent Water <https://www.whatdotheyknow.com/r/505e5178-c611-44f7-b6db-7f1e3c599e0e>`__: data provided but not publicly accessible.
+- 🟢 `Severn Trent Water <https://www.whatdotheyknow.com/request/wastewater_catchment_areas>`__: data provided but not publicly accessible.
 - 🟢 `Southern Water <https://www.whatdotheyknow.com/r/4cde4e22-1df0-42c8-b1a2-02e2cbd45b1b>`__: data provided and publicly accessible.
 - 🔴 `South West Water <https://www.whatdotheyknow.com/r/5bfae578-d74d-4962-850b-3c5851c3ab5a>`__: request refused.
 - 🟢 `Thames Water <https://www.whatdotheyknow.com/r/e5915cbb-dc3b-4797-bf75-fe7cd8eb75c0>`__: data provided and publicly accessible.

--- a/data.shasum
+++ b/data.shasum
@@ -6,6 +6,7 @@ de84441bd99e576303375cf9d291940c4d5e1251  data/raw_catchments/southern_water.zip
 5dabf3e776276ef9a1aa79fc86b11fbb7562d2df  data/raw_catchments/northumbrian_water.zip
 5c13a6f49bf0da816698414f1af7a5b08183a10a  data/raw_catchments/yorkshire_water.zip
 84aea26aff26b4314856278f840bf4e04669d029  data/raw_catchments/scottish_water.zip
+87198ee92c6d15ed869d13b9c603ec5d4e6a3658  data/raw_catchments/severn_trent_water.zip
 0c86146193ac8cd3196ccc4fe39c061c780b5680  data/raw_catchments/wessex_water.zip
 1053a4a9ff9af2997d8f3c46b1ee86fba9177474  data/ons.gov.uk/lsoa_syoa_all_years_t.csv
 888477110e95e6490ee14efa2fb480dc68569901  data/geoportal.statistics.gov.uk/countries20_BGC.zip


### PR DESCRIPTION
Add wastewater catchment areas for Severn Trent Water (fixes #4). Severn Trent made catchment areas available on their website in response to another [Environmental Information Request](https://www.whatdotheyknow.com/request/wastewater_catchment_areas).