### PR TITLE
Fix the failing build due to the archived boundaries going down.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ ${UWWTP_CSVS} : data/eea.europa.eu/download_waterbase.log
 # Write a log file which the raw data rely on in the dependency graph. Otherwise, the download
 # script is executed many times if `make` is launched with the `-j` option.
 data/eea.europa.eu/download_waterbase.log :
+	mkdir -p data/eea.europa.eu/
 	python download_waterbase.py > ${@:.log=.log.tmp}
 	mv ${@:.log=.log.tmp} $@
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ data/geoportal.statistics.gov.uk/LSOA11_BGC.zip :
 # https://geoportal.statistics.gov.uk/datasets/ons::countries-december-2020-uk-bgc/about
 data/geoportal.statistics.gov.uk/countries20_BGC.zip :
 	mkdir -p $(dir $@)
-	${CURL} -o $@ 'https://web.archive.org/web/20230316160948if_/https://opendata.arcgis.com/api/v3/datasets/c8e90f1aaae34ac3ba3d79862000dbd7_0/downloads/data?format=shp&spatialRefId=27700&where=1%3D1'
+	${CURL} -o $@ 'https://web.archive.org/web/20240828001540/https://opendata.arcgis.com/api/v3/datasets/c8e90f1aaae34ac3ba3d79862000dbd7_0/downloads/data?format=shp&spatialRefId=27700&where=1%3D1'
 
 # --------------------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,13 @@ UWWTP_CSVS = data/eea.europa.eu/waterbase_v1_csv/T_UWWTPS.csv \
 
 data/eea.europa.eu : ${UWWTP_CSVS}
 
-${UWWTP_CSVS} :
-	python download_waterbase.py
+${UWWTP_CSVS} : data/eea.europa.eu/download_waterbase.log
+
+# Write a log file which the raw data rely on in the dependency graph. Otherwise, the download
+# script is executed many times if `make` is launched with the `-j` option.
+data/eea.europa.eu/download_waterbase.log :
+	python download_waterbase.py > ${@:.log=.log.tmp}
+	mv ${@:.log=.log.tmp} $@
 
 # --------------------------------------------------------------------------------------------------
 

--- a/data.shasum
+++ b/data.shasum
@@ -9,7 +9,7 @@ de84441bd99e576303375cf9d291940c4d5e1251  data/raw_catchments/southern_water.zip
 87198ee92c6d15ed869d13b9c603ec5d4e6a3658  data/raw_catchments/severn_trent_water.zip
 0c86146193ac8cd3196ccc4fe39c061c780b5680  data/raw_catchments/wessex_water.zip
 1053a4a9ff9af2997d8f3c46b1ee86fba9177474  data/ons.gov.uk/lsoa_syoa_all_years_t.csv
-7187cc4a50dca3945f4bad88fd9645b17a3e926a  data/geoportal.statistics.gov.uk/countries20_BGC.zip
+713db0e159c36d462deb0b22e85ad9d5e3c6415f  data/geoportal.statistics.gov.uk/countries20_BGC.zip
 cf61a9b2fea6621e730f6960a61a7d9f7cf24460  data/geoportal.statistics.gov.uk/LSOA11_BGC.zip
 90b6243cb631fb80d2cf8498b1ace5bb63579070  data/eea.europa.eu/waterbase_v1_csv/T_UWWTPS.csv
 ab17cc0f8947a3c122192808bf70c17af78958fe  data/eea.europa.eu/waterbase_v2_csv/T_UWWTPS.csv


### PR DESCRIPTION
Fix the failing build due to the archived boundaries going down. The web archive seems to have lost the copy previously available at https://web.archive.org/web/20230316160948if_/https://opendata.arcgis.com/api/v3/datasets/c8e90f1aaae34ac3ba3d79862000dbd7_0/downloads/data?format=shp&spatialRefId=27700&where=1%3D1. Or has it been deleted?